### PR TITLE
UI Changes for flex elements in main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+fork from neurocog-mobility/app-trial-sync

--- a/index.html
+++ b/index.html
@@ -20,9 +20,6 @@
                         Neurocognition & Mobility Lab: Time Logger
                     </a>
                 </div>
-                <div style="margin: auto;">
-                    <button id="btn-save" class="btn btn-warning btn-xl" style="margin: auto;">Export</button>
-                </div>
                 </div>
             </nav>
         </div>
@@ -31,8 +28,11 @@
                 <div id="lbl-time">--</div>
                 <div id="pnl-trial" class="bg-white">
                     <div id="lbl-trial">Trial: 1</div>
-                    <div id="pnl-inc">
+                    <div id="pnl-inc" style="border-bottom: solid;padding-bottom: 30px;">
                         <button id="btn-dec" class="btn btn-dark btn-xl">-</button>
+                        <div style="margin: auto;">
+                            <button id="btn-save" class="btn btn-warning btn-xl" style="margin: auto; margin-top: 20vh;">Export</button>
+                        </div>
                         <button id="btn-inc" class="btn btn-dark btn-xl">+</button>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="./src/scss/style.css">
     <title>Time Sync App</title>
 </head>
+    
 <body>
     <div id="container-app">
         <div id="pnl-head">

--- a/index.html
+++ b/index.html
@@ -25,6 +25,10 @@
                 </div>
             </nav>
         </div>
+    </div>
+</body>
+
+<br>
         <div id="pnl-main">
             <div id="pnl-app" class="bg-white">
                 <div id="lbl-time">--</div>
@@ -56,6 +60,5 @@
         </div>
     </div>
 
-</body>
 <script src="./src/js/main.js"></script>
 </html>

--- a/index.html
+++ b/index.html
@@ -26,10 +26,6 @@
                 </div>
             </nav>
         </div>
-    </div>
-</body>
-
-<br>
         <div id="pnl-main">
             <div id="pnl-app" class="bg-white">
                 <div id="lbl-time">--</div>
@@ -60,6 +56,7 @@
             </div>
         </div>
     </div>
+</body>
 
 <script src="./src/js/main.js"></script>
 </html>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
                     <div id="pnl-inc" style="border-bottom: solid;padding-bottom: 30px;">
                         <button id="btn-dec" class="btn btn-dark btn-xl">-</button>
                         <div style="margin: auto;">
-                            <button id="btn-save" class="btn btn-warning btn-xl" style="margin: auto; margin-top: 20vh;">Export</button>
+                            <button id="btn-save" class="btn btn-warning btn-xl" style="margin: auto; margin-top: -10vh;">Export</button>
                         </div>
                         <button id="btn-inc" class="btn btn-dark btn-xl">+</button>
                     </div>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
                 </div>
             </nav>
         </div>
-        <div id="pnl-main">
+        <div id="pnl-main" style="display: flex;">
             <div id="pnl-app" class="bg-white">
                 <div id="lbl-time">--</div>
                 <div id="pnl-trial" class="bg-white">

--- a/src/scss/main.css
+++ b/src/scss/main.css
@@ -8645,8 +8645,8 @@ textarea.form-control-lg {
 }
 
 .bg-white {
-  --bs-bg-opacity: 1;
-  background-color: rgba(var(--bs-white-rgb), var(--bs-bg-opacity)) !important;
+  --bs-bg-opacity: 0;
+background-color: rgb(255, 255, 255) !important;
 }
 
 .bg-body {

--- a/src/scss/style.css
+++ b/src/scss/style.css
@@ -7,9 +7,9 @@
 #pnl-head {height: fit-content; margin: 40px;}
 
 #pnl-main {
-    flex: 1;
+    flex: content;
     display:flex;
-    flex-direction:column
+    flex-direction:column-reverse
 }
 
 #pnl-app {
@@ -32,7 +32,7 @@
     flex-direction:column;
     transform: translate(-50%,-50%);
     left: 50%;
-    top: 60%;
+    top: 50%;
     justify-content: center;
     align-items: center;
     width: 60vw;

--- a/src/scss/style.css
+++ b/src/scss/style.css
@@ -13,7 +13,7 @@
 }
 
 #pnl-app {
-    flex: 2;
+    /*flex: 2; */
     position: relative;
 }
 
@@ -32,10 +32,10 @@
     flex-direction:column;
     transform: translate(-50%,-50%);
     left: 50%;
-    top: 50%;
+    top: 113%;
     justify-content: center;
     align-items: center;
-    width: 60vw;
+    width: 100vw;
 }
 
 #pnl-tbl {
@@ -48,7 +48,7 @@
     text-align: center;
     transform: translate(-50%,-50%);
     left: 50%;
-    top: 85%;
+    top: 129%;
     font-size: 2vh;
     color: slategrey;
 }

--- a/src/scss/style.css
+++ b/src/scss/style.css
@@ -23,6 +23,9 @@
     flex-direction: row;
     justify-content: center;
     align-items: center;
+    top: -20vh;
+    padding-bottom: 100px;
+    margin-top: 122px;
 }
 
 #pnl-trial {
@@ -30,9 +33,7 @@
     /* flex: 1; */
     display:flex;
     flex-direction:column;
-    transform: translate(-50%,-50%);
-    left: 50%;
-    top: 113%;
+    top: 39%;
     justify-content: center;
     align-items: center;
     width: 100vw;
@@ -54,8 +55,8 @@
 }
 #lbl-trial {
     text-align: center;
-    font-size: 4vh;
-    margin: 13vw;
+    font-size: 9vh;
+    margin: 0vw;
 }
 
 #btn-start {

--- a/src/scss/style.css
+++ b/src/scss/style.css
@@ -1,7 +1,7 @@
 #container-app { 
     height: 100vh;
     display:flex;
-    flex-direction:column;
+    flex-direction:row;
   }
   
 #pnl-head {height: fit-content; margin: 40px;}

--- a/src/scss/style.css
+++ b/src/scss/style.css
@@ -1,7 +1,7 @@
 #container-app { 
     height: 100vh;
     display:flex;
-    flex-direction:row;
+    flex-direction:column;
   }
   
 #pnl-head {height: fit-content; margin: 40px;}
@@ -26,8 +26,8 @@
 }
 
 #pnl-trial {
-    position: absolute;
-    flex: 1;
+    position: relative;
+    /* flex: 1; */
     display:flex;
     flex-direction:column;
     transform: translate(-50%,-50%);
@@ -39,8 +39,8 @@
 }
 
 #pnl-tbl {
-    flex: 1;
-    position: relative;
+    /*!  flex: 1; */
+    /*! position: relative; */
 }
 
 #lbl-time {

--- a/src/scss/style.css
+++ b/src/scss/style.css
@@ -54,8 +54,8 @@
 }
 #lbl-trial {
     text-align: center;
-    font-size: 5vh;
-    margin: 4vw;
+    font-size: 4vh;
+    margin: 13vw;
 }
 
 #btn-start {


### PR DESCRIPTION
Changed flex elements of the updating time table, start and stop buttons and trial number box so they don't flex out of the screen during element update.
Changed export button and main title element to not flex with the time table which would block the export button from being accessible after 8 start/stop events. 
Moved start and stop buttons to the bottom of the page so the updating times on the table are easier to keep track (being right above the buttons).

Changed export button to be at the bottom of the page so users don't accidentally swipe up and refresh the page when exporting data

No functionality of the time tables, marks, buttons were made.